### PR TITLE
concurrent modification bug

### DIFF
--- a/src/main/java/dev/tigr/simpleevents/EventManager.java
+++ b/src/main/java/dev/tigr/simpleevents/EventManager.java
@@ -7,6 +7,7 @@ import dev.tigr.simpleevents.listener.EventListener;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Used to post {@link Event}s to {@link EventListener}s and register/unregister {@link EventListener}s
@@ -46,7 +47,7 @@ public class EventManager {
 		List<EventListener> listeners;
 		if(listenerMap.containsKey(eventClass)) listeners = listenerMap.get(eventClass);
 		else {
-			listeners = new ArrayList<>();
+			listeners = new CopyOnWriteArrayList<>();
 			listenerMap.put(eventClass, listeners);
 		}
 


### PR DESCRIPTION
This fixes a bug on concurrent registration events.

```
java.util.ConcurrentModificationException
	at java.util.ArrayList.forEach(ArrayList.java:1262)
	at dev.tigr.simpleevents.EventManager.post(EventManager.java:34)
```

Replaces ArrayList with CopyOnWriteArrayList, should not be a performance problem because cow only happens on insert.

Tested on Java 8.